### PR TITLE
Chat box submit

### DIFF
--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -129,8 +129,10 @@ div.icon {
 }
 
 .chatAction #messageBox {
-    height: 100%;
-    width: 85%;
+  border: var(--light-blue);
+  height: 100%;
+  width: 85%;
+  resize: none;
 }
 
 .chatAction #sendButton {

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -209,25 +209,39 @@ img {
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.50);
 }
 
-#chatbar button{
-  background: var(--dark-green);
-  color: white;
-  height: 55px;
-  width: 10%;
-}
 #e_space {
   background: white;
   height: 10vh;
 }
-#type_msg {
 
+#type_msg {
   width: 100%;
 }
 
-#msg {
+#messageBox {
   border: var(--light-blue);
   min-height: 10px;
   width: 90%;
   resize: none;
+}
 
+#sendButton {
+  background: var(--dark-green);
+  color: white;
+  height: 55px;
+  width: 10%;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  border: solid rgb(200, 200, 200) 1px;
+  cursor: pointer;
+}
+
+#sendButton:hover {
+  background-color: rgb(200, 200, 200);
+}
+
+#sendButtonText {
+    text-align: center;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -37,8 +37,6 @@
     	 
     			<div class="d-flex justify-content-center" id="chatbar">
     				<div class="input-group" id = "type_msg">
-    				  	<textarea id="msg" type="text" placeholder="Type message..."></textarea>
-    				    <button type="button" onclick="getMessage()">Send</button>
     				</div>
        			</div>
     		</div>

--- a/public/javascript/admin.js
+++ b/public/javascript/admin.js
@@ -118,22 +118,15 @@ function toggleChat(userId) {
                 actionDiv.innerHTML = "<button id='accept' onclick='acceptChat(CURRENT_CHAT_USER_ID)'>Accept Thread</button>"
             }
             else if (chat.active) {
-                actionDiv.innerHTML = "<input id='messageBox' type='text' name='messageInput' placeholder='Message' autocomplete='off'>"
-                                    + "<div id='sendButton' onclick='sendMessage()'><div id='sendButtonText'>Send</div></div>";
+                actionDiv.innerHTML = chatElements();
+                chatSetup(sendMessage);
+                scrollDown()
             } else {
                 actionDiv.innerHTML = "<button id='delete' onclick='removeChat(CURRENT_CHAT_USER_ID)'>Delete Thread</button>";
             }
         }
         tabId++;
     }
-    $("#messageBox").on('keyup', function (e) {
-        if (e.keyCode == 13) {
-            sendMessage();
-        }
-    });
-    scrollDown()
-
-
 }
 
 function scrollDown() {
@@ -171,17 +164,12 @@ function sendMessage() {
     message = $('#messageBox').val();
     if (message != '') {
         console.log("sending message")
-        message = $('#messageBox').val();
         send_message(CURRENT_CHAT_USER_ID, message);
         messageObject = createMessage("admin", message);
-
         addMessage(CURRENT_CHAT_USER_ID, messageObject);
-                
         message = $('#messageBox').val('');
     }
-
 }
-
 
 /*
     Given a user identifier and a messageObject, appends the message object to that user's

--- a/public/javascript/chat.js
+++ b/public/javascript/chat.js
@@ -26,7 +26,7 @@ function escapeMessage(message) {
 
 function chatElements() {
   return '<textarea id="messageBox" type="text" autocomplete="off" placeholder="Type a message..."></textarea>'
-       + '<div id="sendButton" onclick="sendMessage()""><div id="sendButtonText">Send</div></div>';
+       + '<div id="sendButton"><div id="sendButtonText">Send</div></div>';
 }
 
 function chatSetup(sendMessage) {
@@ -35,5 +35,9 @@ function chatSetup(sendMessage) {
       e.preventDefault();
       sendMessage();
     }
+  });
+
+  $("#sendButton").click(function(e) {
+    sendMessage();
   });
 }

--- a/public/javascript/chat.js
+++ b/public/javascript/chat.js
@@ -24,3 +24,16 @@ function escapeMessage(message) {
 	return message
 }
 
+function chatElements() {
+  return '<textarea id="messageBox" type="text" autocomplete="off" placeholder="Type a message..."></textarea>'
+       + '<div id="sendButton" onclick="sendMessage()""><div id="sendButtonText">Send</div></div>';
+}
+
+function chatSetup(sendMessage) {
+  $("#messageBox").keydown(function(e) {
+    if (e.which == 13 && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  });
+}

--- a/public/javascript/index.js
+++ b/public/javascript/index.js
@@ -96,20 +96,21 @@ function createMessage(role, messageString) {
 }
 
 function sendMessage() {
-  
-    message = document.getElementById("msg").value;
-    // message = encodeURI(uri);
-    //var new_message = message.split(/[^>]/, '');
-    //console.log(message);
-    //console.log(decodeURI(message));
+    message = $('#messageBox').val();
     if (message != '') {
+        send_message(message);
         messageObject = createMessage('user', message);
         chat.messages.push(messageObject);
-        send_message(message);
         updateChat(messageObject);     
-        message = document.getElementById("msg").value="";
+        message = $('#messageBox').val('');
     }
 }
+
 /* function to change accepted from true to false when admin accepts chat */
 /* function to change active to false when user exits out */
+
+$(function() {
+  $("#type_msg").html(chatElements());
+  chatSetup(sendMessage);
+});
 


### PR DESCRIPTION
chat boxes now use textarea to support wrapped multiline text input and a more stylizable div in place of a submit button. (to achieve line breaks when typing, use shift+enter, however this gets flattened by other front end functions before being sent and displayed)

get the necessary html elements from chat.js with chatElements() and add the corresponding event handlers with chatSetup(sendMessage) where sendMessage is a client implemented function that handles sending the actual message for the client's usage