### PR TITLE
visual indicator for new messages/chats

### DIFF
--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -87,7 +87,7 @@ div.icon {
 .buttonText {
     display: flex;
     flex-direction: column;
-    width: 100%
+    width: 90%
 }
 
 .messagePreview {
@@ -105,6 +105,15 @@ div.icon {
 
 .buttonTypingIcon {
     width: 100%;
+}
+
+.alertBar {
+    width: 10%;
+    min-height: 60px;
+}
+
+.alertBar#alert {
+    background-color: var(--dark-green);
 }
 
 /* Style the tab content */
@@ -144,11 +153,7 @@ div.icon {
     cursor: pointer;
 }
 
-.chatAction {
-
-}
-
-.chatAction #messageBox {
+.chatAction #inputBox {
   border: var(--light-blue);
   height: 100%;
   width: 85%;

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -218,7 +218,7 @@ img {
   width: 100%;
 }
 
-#messageBox {
+#inputBox {
   border: var(--light-blue);
   min-height: 10px;
   width: 90%;

--- a/public/javascript/admin.js
+++ b/public/javascript/admin.js
@@ -127,14 +127,20 @@ function updateUserOverview() {
         iconText[0] = iconText[0].toUp
         userTypingHidden = chat.typing ? '' : 'hidden';
         messagePreview = chat.messages.length == 0 ? '' : chat.messages[chat.messages.length - 1].message;
+        alert = chat.alert ? " id=alert" : '';
         tab.innerHTML = tab.innerHTML 
                       + "<button class='username' " + selectedChat
                       + " onclick='toggleChat(`" + chat.userId + "`)'>"
-                      + iconTag
-                      + "<div class='buttonText'><div class='buttonId'>" + iconText + "</div>"
-                      + "<div class='messagePreview'>" + messagePreview + "</div></div>"
-                      + "<div class='buttonTypingDiv' " + userTypingHidden + ">"
-                      + "<img class='buttonTypingIcon' src='img/typing_icon.png'></div></button>";
+                        + iconTag
+                        + "<div class='buttonText'>"
+                            + "<div class='buttonId'>" + iconText + "</div>"
+                            + "<div class='messagePreview'>" + messagePreview + "</div>"
+                        + "</div>"
+                        + "<div class='buttonTypingDiv' " + userTypingHidden + ">"
+                            + "<img class='buttonTypingIcon' src='img/typing_icon.png'>"
+                        + "</div>"
+                        + "<div class='alertBar'" + alert + "></div>"
+                      + "</button>";
     }
 }
 
@@ -164,7 +170,7 @@ function toggleChat(userId) {
             }
             else if (chat.active) {
                 actionDiv.innerHTML = chatElements();
-                chatSetup(sendMessage);
+                chatSetup(sendMessage, chat);
                 scrollDown()
             } else {
                 actionDiv.innerHTML = "<button id='delete' onclick='removeChat(CURRENT_CHAT_USER_ID)'>Delete Thread</button>";
@@ -172,18 +178,21 @@ function toggleChat(userId) {
         }
         tabId++;
     }
-    $("#messageBox").on('keyup', function (e) {
-        if (e.keyCode == 13) {
-            sendMessage();
-        }
-    });
+
+    // TODO duplicate code? see chat.js 'chatSetup()'
+    // $("#inputBox").on('keyup', function (e) {
+    //     if (e.keyCode == 13) {
+    //         sendMessage();
+    //     }
+    // });
+
     scrollDown()
     updateUserOverview();
 }
 
 function scrollDown() {
-    messageBox = document.getElementsByClassName("messagesBox")[0];
-    messageBox.scrollTop = messageBox.scrollHeight;
+    messagesBox = document.getElementsByClassName("messagesBox")[0];
+    messagesBox.scrollTop = messagesBox.scrollHeight;
 }
 
 
@@ -203,7 +212,7 @@ function newChat(userId, icon) {
         }
     }
     if (validUser) {
-        chats.push({ userId: userId, messages: [], accepted: false, active: true, typing: false, icon: icon });
+        chats.push({ userId: userId, messages: [], accepted: false, active: true, typing: false, icon: icon, alert: true });
     }
 }
 
@@ -214,6 +223,7 @@ function deactivateChat(userId) {
         if (userId == chat.userId) {
             chat.active = false;
             chat.typing = false;
+            chat.alert = true;
             foundUser = true;
             updateUserOverview();
         }
@@ -228,6 +238,7 @@ function acceptChat(userId) {
     for (chat of chats) {
         if (userId == chat.userId) {
             chat.accepted = true;
+            chat.alert = false;
             foundUser = true;
         }
     }
@@ -312,16 +323,16 @@ function createMessage(role, messageString) {
 }
 
 function sendMessage() {
-    message = $('#messageBox').val();
+    message = $('#inputBox').val();
     if (message != '') {
         console.log("sending message")
-        message = $('#messageBox').val();
+        message = $('#inputBox').val();
         send_message(CURRENT_CHAT_USER_ID, message);
         messageObject = createMessage("admin", message);
 
         addMessage(CURRENT_CHAT_USER_ID, messageObject);
                 
-        message = $('#messageBox').val('');
+        message = $('#inputBox').val('');
     }
 
 }
@@ -335,10 +346,15 @@ function addMessage(userId, messageObject) {
     for (chat of chats) {
         if (userId == chat.userId) {
             chat.messages.push(messageObject);
+            chat.alert = true;
             foundUser = true;
             if (userId == CURRENT_CHAT_USER_ID) {
                 currentChat = document.getElementsByClassName("messages")[0];
-                messageSide = messageObject.role == 'admin' ? 'right' : 'left';
+                messageSide = 'left';
+                if (messageObject.role == 'admin') {
+                    chat.alert = false;
+                    messageSide = 'right';
+                }
                 currentChat.innerHTML = currentChat.innerHTML + createMessageDiv(messageSide, messageObject.message);
             }
         }

--- a/public/javascript/chat.js
+++ b/public/javascript/chat.js
@@ -25,12 +25,12 @@ function escapeMessage(message) {
 }
 
 function chatElements() {
-  return '<textarea id="messageBox" type="text" autocomplete="off" placeholder="Type a message..."></textarea>'
+  return '<textarea id="inputBox" type="text" autocomplete="off" placeholder="Type a message..."></textarea>'
        + '<div id="sendButton"><div id="sendButtonText">Send</div></div>';
 }
 
 function chatSetup(sendMessage) {
-  $("#messageBox").keydown(function(e) {
+  $("#inputBox").keydown(function(e) {
     // Check if on user side
     if (typeof(CURRENT_CHAT_USER_ID) == "undefined" && typeof(chat.userId) != "undefined") {
       send_typing_message(true);

--- a/public/javascript/index.js
+++ b/public/javascript/index.js
@@ -112,13 +112,13 @@ function createMessage(role, messageString) {
 }
 
 function sendMessage() {
-    message = $('#messageBox').val();
+    message = $('#inputBox').val();
     if (message != '') {
         send_message(message);
         messageObject = createMessage('user', message);
         chat.messages.push(messageObject);
         updateChat(messageObject);     
-        message = $('#messageBox').val('');
+        message = $('#inputBox').val('');
     }
 }
 


### PR DESCRIPTION
per #135, new messages and chats needed a visual indicator on the admin side.

per the wiki, a 'dark-green' bar is shown on the user button in the left tab if there is an update regarding the user:
- a new user connected
- an existing user sent a new message
- an existing user disconnected

to get rid of the alert indicator, the admin can:
- accept an incoming thread
- send a message back
- delete the thread

chat messageStream object changed
- added 'alert' attribute that is a boolean to indicate if the alert indicator should be displayed in the user tab. change documented in wiki

other changes in this commit include renaming text input area messageBox -> inputBox to avoid confusion with message display area messagesBox