### PR TITLE
Fixed toggle chat error:

### DIFF
--- a/public/javascript/admin.js
+++ b/public/javascript/admin.js
@@ -359,7 +359,7 @@ function addMessage(userId, messageObject) {
                     chat.alert = false;
                     messageSide = 'right';
                 }
-                $("#typingIcon").before(createMessageDiv(messageSide, messageObject.message));
+                currentChat.innerHTML = currentChat.innerHTML + createMessageDiv(messageSide, messageObject.message);
             }
         }
         scrollDown();


### PR DESCRIPTION
New chats would add the text of the currently viewed chat to the
newly accepted one. Reverted to code in commit
b443b29fc2db66ddd2143180c7f2c872803ba795